### PR TITLE
chore: include style as a type-enum

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 ﻿module.exports = {
   rules: {
     "type-case": [2, "always", "lower-case"],
-    "type-enum": [2, "always", ["chore", "ci", "docs", "feat", "fix", "test"]],
+    "type-enum": [2, "always", ["chore", "ci", "docs", "feat", "fix", "test", "style"]],
     "subject-case": [2, "always", "sentence-case"],
     "subject-max-length": [2, "always", 50],
     "subject-empty": [2, "never"],


### PR DESCRIPTION
**Changes proposed**

Include a new type-enum for changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc). The Angular convention usually uses the prefix `style` for this type of change.