### PR TITLE
chore: allow lower case subject

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
   rules: {
     "type-case": [2, "always", "lower-case"],
     "type-enum": [2, "always", ["chore", "ci", "docs", "feat", "fix", "test", "style"]],
-    "subject-case": [2, "always", "sentence-case"],
+    "subject-case": [2, "always", ["sentence-case", "lower-case"]],
     "subject-max-length": [2, "always", 50],
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "@rocketseat/commitlint-config",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Shareable commitlint config used by Rocketseat",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
This PR updates the config to support lower case subject. 

With this change, the following commits are valid:

`chore: Test`
`chore: test`

Before, just the first commit was a valid one.

